### PR TITLE
Improve Hearthstone alerting systems (flash & popup)

### DIFF
--- a/Hearthstone Deck Tracker/Config.cs
+++ b/Hearthstone Deck Tracker/Config.cs
@@ -143,8 +143,11 @@ namespace Hearthstone_Deck_Tracker
 		[DefaultValue("Dungeon Run {Date dd-MM HH:mm}")]
 		public string DungeonRunDeckNameTemplate = "Dungeon Run {Date dd-MM HH:mm}";
 
-		[DefaultValue(false)]
-		public bool BringHsToForeground = false;
+		[DefaultValue(HsActionType.Flash)]
+		public HsActionType TurnStartAction = HsActionType.Flash;
+
+		[DefaultValue(HsActionType.Flash)]
+		public HsActionType ChallengeAction = HsActionType.Flash;
 
 		[DefaultValue(false)]
 		public bool CardSortingClassFirst = false;
@@ -319,12 +322,6 @@ namespace Hearthstone_Deck_Tracker
 
 		[DefaultValue(false)]
 		public bool ExtraFeaturesSecrets = false;
-
-		[DefaultValue(true)]
-		public bool FlashHsOnTurnStart = true;
-
-		[DefaultValue(false)]
-		public bool FlashHsOnFriendlyChallenge = false;
 
 		[DefaultValue(false)]
 		public bool ForceMouseHook = false;

--- a/Hearthstone Deck Tracker/Enums/HsActionType.cs
+++ b/Hearthstone Deck Tracker/Enums/HsActionType.cs
@@ -1,0 +1,12 @@
+﻿namespace Hearthstone_Deck_Tracker.Enums
+{
+	public enum HsActionType
+	{
+		[LocDescription("Enum_HsActionType_None")]
+		None,
+		[LocDescription("Enum_HsActionType_Flash")]
+		Flash,
+		[LocDescription("Enum_HsActionType_Popup")]
+		Popup
+	}
+}

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerGeneral.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerGeneral.xaml
@@ -11,40 +11,6 @@
              mc:Ignorable="d"
              d:DesignHeight="500" d:DesignWidth="300">
     <StackPanel>
-        <GroupBox Header="{lex:LocTextUpper Options_Tracker_General_Label_Alerts}">
-            <StackPanel>
-                <CheckBox x:Name="CheckboxFlashHs" Content="{lex:Loc Options_Tracker_General_CheckBox_Flash}"
-                      HorizontalAlignment="Left" Margin="10,0,0,0" VerticalAlignment="Top"
-                      Checked="CheckboxFlashHs_Checked"
-                      Unchecked="CheckboxFlashHs_Unchecked" />
-                <CheckBox x:Name="CheckboxFlashHsOnChallenge" Content="{lex:Loc Options_Tracker_General_CheckBox_Flash_Challenge}"
-                      HorizontalAlignment="Left" Margin="10,5,0,0" VerticalAlignment="Top"
-                      Checked="CheckboxFlashHsOnChallenge_Checked"
-                      Unchecked="CheckboxFlashHsOnChallenge_Unchecked" />
-                <CheckBox x:Name="CheckboxBringHsToForegorund"
-                      Content="{lex:Loc Options_Tracker_General_CheckBox_Popup}" HorizontalAlignment="Left"
-                      Margin="10,5,0,0" VerticalAlignment="Top"
-                      Checked="CheckboxBringHsToForegorund_Checked"
-                      Unchecked="CheckboxBringHsToForegorund_Unchecked" />
-                <DockPanel Margin="10,5,10,0" Visibility="{Binding Visibility, Source={x:Static options:AdvancedOptions.Instance}}">
-                    <CheckBox x:Name="CheckboxTimerAlert"
-                          HorizontalAlignment="Left" Margin="0,5,0,0"
-                          ToolTip="{lex:Loc Options_Tracker_General_Label_TimerAlert_Tooltip}"
-                          VerticalAlignment="Top" Checked="CheckboxTimerAlert_Checked"
-                          Unchecked="CheckboxTimerAlert_Unchecked">
-                        <StackPanel Orientation="Horizontal" Margin="0,-5,0,0">
-                            <Label Content="{lex:Loc Options_Tracker_General_Label_TimerAlert}" Foreground="{Binding Color, Source={x:Static options:AdvancedOptions.Instance}}"/>
-                            <TextBox x:Name="TextboxTimerAlert"
-                             HorizontalAlignment="Right" Height="23" HorizontalContentAlignment="Center"
-                             Margin="10,0,0,0" TextWrapping="Wrap" Text="30" VerticalAlignment="Top"
-                             Width="60" TextChanged="TextboxTimerAlert_TextChanged"
-                             PreviewTextInput="TextboxTimerAlert_PreviewTextInput" />
-                            <Label Content="{lex:Loc Options_Tracker_General_Label_TimerAlert2}" Foreground="{Binding Color, Source={x:Static options:AdvancedOptions.Instance}}"/>
-                        </StackPanel>
-                    </CheckBox>
-                </DockPanel>
-            </StackPanel>
-        </GroupBox>
         <GroupBox Header="{lex:LocTextUpper Options_Tracker_General_Label_CardLanguage}">
             <StackPanel>
                 <DockPanel Margin="0,5,0,0">

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerGeneral.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerGeneral.xaml.cs
@@ -35,19 +35,14 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			CheckBoxAutoDeckDetection.IsChecked = Config.Instance.AutoDeckDetection;
 			CheckboxHideManaCurveMyDecks.IsChecked = Config.Instance.ManaCurveMyDecks;
 			CheckboxTrackerCardToolTips.IsChecked = Config.Instance.TrackerCardToolTips;
-			CheckboxBringHsToForegorund.IsChecked = Config.Instance.BringHsToForeground;
-			CheckboxFlashHs.IsChecked = Config.Instance.FlashHsOnTurnStart;
-			CheckboxTimerAlert.IsChecked = Config.Instance.TimerAlert;
 			CheckBoxClassCardsFirst.IsChecked = Config.Instance.CardSortingClassFirst;
-			TextboxTimerAlert.Text = Config.Instance.TimerAlertSeconds.ToString();
 			ComboboxLanguages.ItemsSource = Helper.LanguageDict.Keys.Where(x => x != "English (Great Britain)");
 			CheckboxDeckPickerCaps.IsChecked = Config.Instance.DeckPickerCaps;
 			ComboBoxLastPlayedDateFormat.ItemsSource = Enum.GetValues(typeof(LastPlayedDateFormat));
 			CheckBoxShowLastPlayedDate.IsChecked = Config.Instance.ShowLastPlayedDateOnDeck;
 			ComboBoxLastPlayedDateFormat.SelectedItem = Config.Instance.LastPlayedDateFormat;
 			CheckboxShowMyGamesPanel.IsChecked = Config.Instance.ShowMyGamesPanel;
-			CheckboxFlashHsOnChallenge.IsChecked = Config.Instance.FlashHsOnFriendlyChallenge;
-
+			
 			if(Config.Instance.NonLatinUseDefaultFont == null)
 			{
 				Config.Instance.NonLatinUseDefaultFont = Helper.IsWindows10();
@@ -114,103 +109,7 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			Config.Instance.UseFullTextSearch = false;
 			Config.Save();
 		}
-
-		private void TextboxTimerAlert_PreviewTextInput(object sender, TextCompositionEventArgs e)
-		{
-			if(!char.IsDigit(e.Text, e.Text.Length - 1))
-				e.Handled = true;
-		}
-
-		private void TextboxTimerAlert_TextChanged(object sender, TextChangedEventArgs e)
-		{
-			if(!_initialized || CheckboxTimerAlert.IsChecked != true)
-				return;
-			int mTimerAlertValue;
-			if(int.TryParse(TextboxTimerAlert.Text, out mTimerAlertValue))
-			{
-				if(mTimerAlertValue < 0)
-				{
-					TextboxTimerAlert.Text = "0";
-					mTimerAlertValue = 0;
-				}
-
-				if(mTimerAlertValue > 90)
-				{
-					TextboxTimerAlert.Text = "90";
-					mTimerAlertValue = 90;
-				}
-
-				Config.Instance.TimerAlertSeconds = mTimerAlertValue;
-				Config.Save();
-			}
-		}
-
-		private void CheckboxBringHsToForegorund_Checked(object sender, RoutedEventArgs e)
-		{
-			if(!_initialized)
-				return;
-			Config.Instance.BringHsToForeground = true;
-			Config.Save();
-		}
-
-		private void CheckboxBringHsToForegorund_Unchecked(object sender, RoutedEventArgs e)
-		{
-			if(!_initialized)
-				return;
-			Config.Instance.BringHsToForeground = false;
-			Config.Save();
-		}
-
-		private void CheckboxFlashHs_Checked(object sender, RoutedEventArgs e)
-		{
-			if(!_initialized)
-				return;
-			Config.Instance.FlashHsOnTurnStart = true;
-			Config.Save();
-		}
-
-		private void CheckboxFlashHs_Unchecked(object sender, RoutedEventArgs e)
-		{
-			if(!_initialized)
-				return;
-			Config.Instance.FlashHsOnTurnStart = false;
-			Config.Save();
-		}
-
-		private void CheckboxFlashHsOnChallenge_Checked(object sender, RoutedEventArgs e)
-		{
-			if(!_initialized)
-				return;
-			Config.Instance.FlashHsOnFriendlyChallenge = true;
-			Config.Save();
-		}
-
-		private void CheckboxFlashHsOnChallenge_Unchecked(object sender, RoutedEventArgs e)
-		{
-			if(!_initialized)
-				return;
-			Config.Instance.FlashHsOnFriendlyChallenge = false;
-			Config.Save();
-		}
-
-		private void CheckboxTimerAlert_Checked(object sender, RoutedEventArgs e)
-		{
-			if(!_initialized)
-				return;
-			Config.Instance.TimerAlert = true;
-			TextboxTimerAlert.IsEnabled = true;
-			Config.Save();
-		}
-
-		private void CheckboxTimerAlert_Unchecked(object sender, RoutedEventArgs e)
-		{
-			if(!_initialized)
-				return;
-			Config.Instance.TimerAlert = false;
-			TextboxTimerAlert.IsEnabled = false;
-			Config.Save();
-		}
-
+		
 		private void CheckBoxAutoUse_OnChecked(object sender, RoutedEventArgs e)
 		{
 			if(!_initialized)

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerNotifications.xaml
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerNotifications.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:options="clr-namespace:Hearthstone_Deck_Tracker.FlyoutControls.Options"
              xmlns:lex="http://wpflocalizeextension.codeplex.com"
              lex:LocalizeDictionary.DesignCulture="en"
              lex:ResxLocalizationProvider.DefaultAssembly="HearthstoneDeckTracker"
@@ -10,12 +11,54 @@
              mc:Ignorable="d"
              d:DesignHeight="600" d:DesignWidth="300">
     <StackPanel>
+        <GroupBox Header="{lex:LocTextUpper Options_Tracker_Notifications_Label_Alerts}">
+            <StackPanel>
+                <DockPanel>
+                    <Label Content="{lex:Loc Options_Tracker_Notifications_Label_TurnStart}"/>
+                    <ComboBox x:Name="ComboboxTurnAction" HorizontalAlignment="Right" Width="150"
+                      SelectionChanged="ComboboxTurnAction_SelectionChanged">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Path=., Converter={StaticResource EnumDescriptionConverter}}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                </DockPanel>
+                <DockPanel Margin="0,5,0,0">
+                    <Label Content="{lex:Loc Options_Tracker_Notifications_Label_FriendlyChallenge}"/>
+                    <ComboBox x:Name="ComboboxChallengeAction" HorizontalAlignment="Right" Width="150"
+                      SelectionChanged="ComboboxChallengeAction_SelectionChanged">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Path=., Converter={StaticResource EnumDescriptionConverter}}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                </DockPanel>
+                <DockPanel Margin="0,5,0,0" Visibility="{Binding Visibility, Source={x:Static options:AdvancedOptions.Instance}}">
+                    <CheckBox x:Name="CheckboxTimerAlert2" HorizontalAlignment="Left"
+                          ToolTip="{lex:Loc Options_Tracker_General_Label_TimerAlert_Tooltip}"
+                          VerticalAlignment="Top" Checked="CheckboxTimerAlert2_Checked"
+                          Unchecked="CheckboxTimerAlert2_Unchecked">
+                        <StackPanel Orientation="Horizontal" Margin="-5,0,0,0">
+                            <Label Content="{lex:Loc Options_Tracker_General_Label_TimerAlert}" Foreground="{Binding Color, Source={x:Static options:AdvancedOptions.Instance}}"/>
+                            <TextBox x:Name="TextboxTimerAlert2"
+                             HorizontalAlignment="Right" Height="23" HorizontalContentAlignment="Center"
+                             Margin="0,0,0,0" TextWrapping="Wrap" Text="30" VerticalAlignment="Top"
+                             Width="60" TextChanged="TextboxTimerAlert2_TextChanged"
+                             PreviewTextInput="TextboxTimerAlert2_PreviewTextInput" />
+                            <Label Content="{lex:Loc Options_Tracker_General_Label_TimerAlert2}" Foreground="{Binding Color, Source={x:Static options:AdvancedOptions.Instance}}"/>
+                        </StackPanel>
+                    </CheckBox>
+                </DockPanel>
+            </StackPanel>
+        </GroupBox>
         <GroupBox Header="{lex:LocTextUpper Options_Tracker_Notifications_Label_GameResult}">
             <StackPanel>
                 <CheckBox Name="CheckBoxShowNotifications" Content="{lex:Loc Options_Tracker_Notifications_Label_ShowNotifications}"
                           Checked="CheckBoxShowNotifications_OnChecked"
                           Unchecked="CheckBoxShowNotifications_OnUnchecked" />
-                <StackPanel Orientation="Horizontal" Margin="0,5,0,0"
+                <StackPanel Orientation="Horizontal" Margin="5,5,0,0"
                             IsEnabled="{Binding Path=IsChecked, ElementName=CheckBoxShowNotifications}">
                     <TextBlock Text="{lex:Loc Options_Tracker_Notifications_Label_Duration}" VerticalAlignment="Center" />
                     <TextBox x:Name="TextboxTimerAlert"

--- a/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerNotifications.xaml.cs
+++ b/Hearthstone Deck Tracker/FlyoutControls/Options/Tracker/TrackerNotifications.xaml.cs
@@ -1,5 +1,8 @@
 ﻿#region
 
+using Hearthstone_Deck_Tracker.Enums;
+using System;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -27,6 +30,15 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			CheckboxNoteDialogDelayed.IsChecked = Config.Instance.NoteDialogDelayed;
 			CheckboxNoteDialogDelayed.IsEnabled = Config.Instance.ShowNoteDialogAfterGame;
 			CheckboxArenaRewardDialog.IsChecked = Config.Instance.ArenaRewardDialog;
+			ComboboxTurnAction.ItemsSource = Enum.GetValues(typeof(HsActionType)).Cast<HsActionType>();
+			ComboboxTurnAction.SelectedIndex = (int)Config.Instance.TurnStartAction;
+			ComboboxChallengeAction.ItemsSource = Enum.GetValues(typeof(HsActionType)).Cast<HsActionType>();
+			ComboboxChallengeAction.SelectedIndex = (int)Config.Instance.ChallengeAction;
+
+
+			CheckboxTimerAlert2.IsChecked = Config.Instance.TimerAlert;
+			TextboxTimerAlert2.Text = Config.Instance.TimerAlertSeconds.ToString();
+
 			_initialized = true;
 		}
 
@@ -123,6 +135,69 @@ namespace Hearthstone_Deck_Tracker.FlyoutControls.Options.Tracker
 			if (!_initialized)
 				return;
 			Config.Instance.ArenaRewardDialog = false;
+			Config.Save();
+		}
+
+		private void CheckboxTimerAlert2_Checked(object sender, RoutedEventArgs e)
+		{
+			if (!_initialized)
+				return;
+			Config.Instance.TimerAlert = true;
+			TextboxTimerAlert2.IsEnabled = true;
+			Config.Save();
+		}
+
+		private void CheckboxTimerAlert2_Unchecked(object sender, RoutedEventArgs e)
+		{
+			if (!_initialized)
+				return;
+			Config.Instance.TimerAlert = false;
+			TextboxTimerAlert2.IsEnabled = false;
+			Config.Save();
+		}
+
+		private void TextboxTimerAlert2_TextChanged(object sender, TextChangedEventArgs e)
+		{
+			if (!_initialized || CheckboxTimerAlert2.IsChecked != true)
+				return;
+			if (int.TryParse(TextboxTimerAlert2.Text, out var mTimerAlertValue))
+			{
+				if (mTimerAlertValue < 0)
+				{
+					TextboxTimerAlert2.Text = "0";
+					mTimerAlertValue = 0;
+				}
+
+				if (mTimerAlertValue > 90)
+				{
+					TextboxTimerAlert2.Text = "90";
+					mTimerAlertValue = 90;
+				}
+
+				Config.Instance.TimerAlertSeconds = mTimerAlertValue;
+				Config.Save();
+			}
+		}
+
+		private void TextboxTimerAlert2_PreviewTextInput(object sender, TextCompositionEventArgs e)
+		{
+			if (!char.IsDigit(e.Text, e.Text.Length - 1))
+				e.Handled = true;
+		}
+
+		private void ComboboxTurnAction_SelectionChanged(object sender, SelectionChangedEventArgs e)
+		{
+			if (!_initialized)
+				return;
+			Config.Instance.TurnStartAction = (HsActionType)ComboboxTurnAction.SelectedIndex;
+			Config.Save();
+		}
+
+		private void ComboboxChallengeAction_SelectionChanged(object sender, SelectionChangedEventArgs e)
+		{
+			if (!_initialized)
+				return;
+			Config.Instance.ChallengeAction = (HsActionType)ComboboxChallengeAction.SelectedIndex;
 			Config.Save();
 		}
 	}

--- a/Hearthstone Deck Tracker/GameEventHandler.cs
+++ b/Hearthstone Deck Tracker/GameEventHandler.cs
@@ -301,11 +301,15 @@ namespace Hearthstone_Deck_Tracker
 			TurnTimer.Instance.SetPlayer(player);
 			if(player == ActivePlayer.Player && !_game.IsInMenu)
 			{
-				if(Config.Instance.FlashHsOnTurnStart)
-					User32.FlashHs();
-
-				if(Config.Instance.BringHsToForeground)
-					User32.BringHsToForeground();
+				switch (Config.Instance.TurnStartAction)
+				{
+						case HsActionType.Flash:
+							User32.FlashHs();
+							break;
+						case HsActionType.Popup:
+							User32.BringHsToForeground();
+							break;
+				}
 			}
 		}
 
@@ -332,10 +336,15 @@ namespace Hearthstone_Deck_Tracker
 			_lastGameStart = DateTime.Now;
 			Log.Info("--- Game start ---");
 
-			if(Config.Instance.FlashHsOnTurnStart)
-				User32.FlashHs();
-			if(Config.Instance.BringHsToForeground)
-				User32.BringHsToForeground();
+			switch (Config.Instance.TurnStartAction)
+			{
+				case HsActionType.Flash:
+					User32.FlashHs();
+					break;
+				case HsActionType.Popup:
+					User32.BringHsToForeground();
+					break;
+			}
 			_lastTurnStart[0] = _lastTurnStart[1] = 0;
 			_arenaRewardDialog = null;
 			_showedNoteDialog = false;

--- a/Hearthstone Deck Tracker/Hearthstone Deck Tracker.csproj
+++ b/Hearthstone Deck Tracker/Hearthstone Deck Tracker.csproj
@@ -253,6 +253,7 @@
     <Compile Include="Controls\StatusIndicator.xaml.cs">
       <DependentUpon>StatusIndicator.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Enums\HsActionType.cs" />
     <Compile Include="FlyoutControls\Options\HSReplay\HSReplayAccount.xaml.cs">
       <DependentUpon>HSReplayAccount.xaml</DependentUpon>
     </Compile>

--- a/Hearthstone Deck Tracker/Hearthstone/Watchers.cs
+++ b/Hearthstone Deck Tracker/Hearthstone/Watchers.cs
@@ -33,8 +33,18 @@ namespace Hearthstone_Deck_Tracker.Hearthstone
 
 		internal static void OnFriendlyChallenge(object sender, HearthWatcher.EventArgs.FriendlyChallengeEventArgs args)
 		{
-			if(args.DialogVisible && Config.Instance.FlashHsOnFriendlyChallenge)
-				User32.FlashHs();
+			if (args.DialogVisible)
+			{
+				switch (Config.Instance.ChallengeAction)
+				{
+					case HsActionType.Flash:
+						User32.FlashHs();
+						break;
+					case HsActionType.Popup:
+						User32.BringHsToForeground();
+						break;
+				}
+			}
 		}
 
 		public static ArenaWatcher ArenaWatcher { get; } = new ArenaWatcher(new HearthMirrorArenaProvider());

--- a/Hearthstone Deck Tracker/LogReader/Handlers/LoadingScreenHandler.cs
+++ b/Hearthstone Deck Tracker/LogReader/Handlers/LoadingScreenHandler.cs
@@ -77,13 +77,10 @@ namespace Hearthstone_Deck_Tracker.LogReader.Handlers
 				else
 					Watchers.DungeonRunWatcher.Stop();
 
-				if(Config.Instance.FlashHsOnFriendlyChallenge)
-				{
-					if(game.PlayerChallengeable)
-						Watchers.FriendlyChallengeWatcher.Run();
-					else
-						Watchers.FriendlyChallengeWatcher.Stop(); 
-				}
+				if(game.PlayerChallengeable && Config.Instance.ChallengeAction != Enums.HsActionType.None)
+					Watchers.FriendlyChallengeWatcher.Run();
+				else
+					Watchers.FriendlyChallengeWatcher.Stop(); 
 
 				API.GameEvents.OnModeChanged.Execute(game.CurrentMode);
 			}


### PR DESCRIPTION
* Moved Alerts section from General to Notifications

* Added TurnAction and ChallengeAction property

* Updated alert configuration section for turn start and friendly challenge

* Fixed issue where the properties were not being set

* Using correct key for popup on challenge text

* Implemented popup functionality on turn start and friendly challenge

* Renamed TurnAction to TurnStartAction

* Made TurnStartAction and ChallengeAction not nullable

* Updated code to work with non nullable properties

* Populating combo box with HsActionType and removed unecessary code

* Adjusted margins

* Only run watcher if challenge action is not equal to None

* Adjusted margin to match the other text controls

<!--- Please read the Contributon Guidelines before submitting your Pull Request -->
<!--- https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing -->

- [ ] I have read the [Contributing Guidelines](https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributing)
- [ ] I have already signed the CLA <!--- See https://github.com/HearthSim/Hearthstone-Deck-Tracker/blob/master/CONTRIBUTING.md#contributor-license-agreement -->
